### PR TITLE
feat: implement Phase 1 Session Prompts foundation

### DIFF
--- a/.env-mcp-inspector
+++ b/.env-mcp-inspector
@@ -1,0 +1,8 @@
+# MCP Inspector Configuration
+# This file is used to configure the MCP Inspector environment for development.
+CLIENT_PORT=8881
+SERVER_PORT=9991
+DANGEROUSLY_OMIT_AUTH=true
+DEBUG=true
+HOST=localhost
+# MCP_PROXY_FULL_ADDRESS=http://localhost:9991

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@ __pycache__/
 # C extensions
 *.so
 
+# Poetry
+poetry.lock
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
 # Distribution / packaging
 .Python
 build/

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+	"servers": {
+		"astral-api": {
+			"command": "poetry",
+			"args": [
+				"run",
+				"start-server"
+			],
+			"cwd": "${workspaceFolder}",
+			"type": "stdio"
+		},
+		"mcp-inspector": {
+			"command": "npx",
+			"args": [
+				"@modelcontextprotocol/inspector@0.16.2",
+				"poetry",
+				"run",
+				"start-server"
+			],
+			"cwd": "${workspaceFolder}",
+			"envFile": "${workspaceFolder}/.env-mcp-inspector",
+			"type": "stdio"
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ poetry run python -c "import asyncio; from astral_mcp_server.server import check
 
 ### Testing the MCP Server
 
-**Important**: MCP servers don't run as web servers - they communicate via the MCP protocol. Here's how to test your server:
+> **Important**: MCP servers don't run as web servers - they communicate via the MCP protocol.
 
-1. **Test with MCP Inspector (interactive debugging)**:
+**Test with MCP Inspector (interactive debugging)**:
 
 ```bash
 poetry run mcp dev astral_mcp_server/server.py
@@ -73,7 +73,7 @@ poetry run mcp dev astral_mcp_server/server.py
 
 Alternatively, you can start the MCP Inspector from [mcp.json](.vscode/mcp.json) via the UI in VSCode.
 
-This will open the MCP Inspector in your browser where you can:
+This will open the [MCP Inspector tool](https://github.com/modelcontextprotocol/inspector) in your browser where you can:
 
 - See available tools (`check_astral_api_health`, `get_server_info`)
 - Execute tools interactively
@@ -81,7 +81,7 @@ This will open the MCP Inspector in your browser where you can:
 
 > The [.env-mcp-inspector](.env-mcp-inspector) file sets environment variables that the MCP Inspector uses to connect to the MCP server. You can modify it if needed.
 
-2. **Use with Claude Desktop or other MCP clients**:
+**Use with Claude Desktop or other MCP clients**:
 
 The following configurations allow you to connect the MCP server with clients like Claude Desktop or VSCode MCP extension.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A MCP (Model Context Protocol) server that enables AI models to query location attestations using the available Astral GraphQL endpoints and APIs.
 
+**Table of Contents**
+- [Project Overview](#project-overview)
+- [Integration with the Recall Platform](#integration-with-the-recall-platform)
+- [Quick Start](#quick-start)
+
+
 ## Quick Start
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ A MCP (Model Context Protocol) server that enables AI models to query location a
 - [Integration with the Recall Platform](#integration-with-the-recall-platform)
 - [Quick Start](#quick-start)
 
+## Project Overview
+
+We are exploring the development of a Model Context Protocol (MCP) agent that integrates with the [Astral API](https://docs.astral.global/getting-started) to enable intelligent querying and analysis of attestations submitted to blockchain ecosystems such as the Ethereum Attestation Service (EAS). This agent would support complex queries across spatial and temporal dimensions, such as filtering attestations by schema ID, location, or date range, while maintaining persistent context across sessions. By leveraging Astral’s structured API and EAS’s open schema model, the agent could automate common analytical workflows—like generating attestation heatmaps or tracking schema usage over time—making it a valuable tool for both research and production use cases. This early scoping phase would help assess feasibility and determine if this direction merits further investment.
+
+To learn more, please refer to the following [document](docs/ai/README.md) for additional details on the purpose, use cases, architecture, and development plans.
+
+## Integration with the Recall Platform
+
+[Recall](https://docs.recall.network/advanced/overview) is a blockchain-based platform to support persistent, intelligent agents for onchain storage primitives and agent collaboration tools, enabling AI agents to maintain persistent memory, share data across sessions, and participate in a broader ecosystem of interconnected agents. By integrating the Astral MCP agent with Recall, we can transform it from a standalone location attestation query tool into a collaborative participant in an agent network with long-term memory—enabling it to store spatial analysis insights onchain, build knowledge graphs of location patterns over time, and share geospatial intelligence with other agents in the ecosystem. This integration unlocks powerful capabilities like persistent session context, cross-agent location verification services, and the ability to contribute to community-driven location intelligence, positioning your agent as both a consumer and provider of valuable spatial data within a growing network of AI agents that can learn from and build upon each other's discoveries.
+
+Once the Astral MCP agent is functional, we plan to integrate it with the Recall platform to enable persistent memory by storing insights onchain. You can find out more details on this next stage of development [in the following section](./docs/integration-with-recall.md).
+
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,67 @@
 
 A MCP (Model Context Protocol) server that enables AI models to query location attestations using the available Astral GraphQL endpoints and APIs.
 
+## Quick Start
+
+### Prerequisites
+- Python 3.12+ (tested with Python 3.13)
+- Poetry for dependency management
+
+### Installation
+
+1. Clone the repository:
+```bash
+git clone <repository-url>
+cd astral-api-mcp
+```
+
+2. Install dependencies using Poetry:
+```bash
+poetry install
+```
+
+3. Verify the installation:
+```bash
+poetry run python -c "import astral_mcp_server; print('Installation successful!')"
+```
+
+4. Test API connectivity:
+```bash
+poetry run python -c "import asyncio; from astral_mcp_server.server import check_astral_api_health; print('Health check:', asyncio.run(check_astral_api_health())['status'])"
+```
+
+### Running the MCP Server
+
+1. Start the server directly:
+```bash
+poetry run python -m astral_mcp_server.server
+```
+
+2. Or use the MCP development tools:
+```bash
+poetry run mcp dev astral_mcp_server/server.py
+```
+
+### Testing
+
+Run the test suite:
+```bash
+poetry run pytest tests/ -v
+```
+
+### Available Tools
+
+- `check_astral_api_health`: Verify connectivity to the Astral API
+- `get_server_info`: Get information about the MCP server instance
+
+### Development
+
+This project uses:
+- **Poetry** for dependency management
+- **FastMCP** framework for MCP server implementation
+- **httpx** for HTTP requests to Astral API
+- **pytest** for testing
+
 ## Project Overview
 
 We are exploring the development of a Model Context Protocol (MCP) agent that integrates with the [Astral API](https://docs.astral.global/getting-started) to enable intelligent querying and analysis of attestations submitted to blockchain ecosystems such as the Ethereum Attestation Service (EAS). This agent would support complex queries across spatial and temporal dimensions, such as filtering attestations by schema ID, location, or date range, while maintaining persistent context across sessions. By leveraging Astral’s structured API and EAS’s open schema model, the agent could automate common analytical workflows—like generating attestation heatmaps or tracking schema usage over time—making it a valuable tool for both research and production use cases. This early scoping phase would help assess feasibility and determine if this direction merits further investment.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,17 @@
 A MCP (Model Context Protocol) server that enables AI models to query location attestations using the available Astral GraphQL endpoints and APIs.
 
 **Table of Contents**
-- [Project Overview](#project-overview)
-- [Integration with the Recall Platform](#integration-with-the-recall-platform)
-- [Quick Start](#quick-start)
+- [astral-api-mcp](#astral-api-mcp)
+  - [Project Overview](#project-overview)
+  - [Integration with the Recall Platform](#integration-with-the-recall-platform)
+  - [Quick Start](#quick-start)
+    - [Prerequisites](#prerequisites)
+    - [Installation](#installation)
+    - [Testing the MCP Server](#testing-the-mcp-server)
+    - [Testing](#testing)
+    - [Available Tools](#available-tools)
+    - [Development](#development)
+    - [Troubleshooting](#troubleshooting)
 
 ## Project Overview
 
@@ -19,51 +27,98 @@ To learn more, please refer to the following [document](docs/ai/README.md) for a
 
 Once the Astral MCP agent is functional, we plan to integrate it with the Recall platform to enable persistent memory by storing insights onchain. You can find out more details on this next stage of development [in the following section](./docs/integration-with-recall.md).
 
-
 ## Quick Start
 
 ### Prerequisites
+
 - Python 3.12+ (tested with Python 3.13)
 - Poetry for dependency management
 
 ### Installation
 
 1. Clone the repository:
+
 ```bash
 git clone <repository-url>
 cd astral-api-mcp
 ```
 
 2. Install dependencies using Poetry:
+
 ```bash
 poetry install
 ```
 
 3. Verify the installation:
+
 ```bash
 poetry run python -c "import astral_mcp_server; print('Installation successful!')"
 ```
 
 4. Test API connectivity:
+
 ```bash
 poetry run python -c "import asyncio; from astral_mcp_server.server import check_astral_api_health; print('Health check:', asyncio.run(check_astral_api_health())['status'])"
 ```
 
-### Running the MCP Server
+### Testing the MCP Server
 
-1. Start the server directly:
-```bash
-poetry run python -m astral_mcp_server.server
-```
+**Important**: MCP servers don't run as web servers - they communicate via the MCP protocol. Here's how to test your server:
 
-2. Or use the MCP development tools:
+1. **Test with MCP Inspector (interactive debugging)**:
+
 ```bash
 poetry run mcp dev astral_mcp_server/server.py
 ```
 
+Alternatively, you can start the MCP Inspector from [mcp.json](.vscode/mcp.json) via the UI in VSCode.
+
+This will open the MCP Inspector in your browser where you can:
+
+- See available tools (`check_astral_api_health`, `get_server_info`)
+- Execute tools interactively
+- View tool outputs and debug
+
+> The [.env-mcp-inspector](.env-mcp-inspector) file sets environment variables that the MCP Inspector uses to connect to the MCP server. You can modify it if needed.
+
+2. **Use with Claude Desktop or other MCP clients**:
+
+The following configurations allow you to connect the MCP server with clients like Claude Desktop or VSCode MCP extension.
+
+**Claude Desktop's config:**
+
+```json
+{
+  "mcpServers": {
+    "astral-api": {
+      "command": "poetry",
+      "args": ["run", "start-server"],
+      "cwd": "/path/to/astral-api-mcp" // the local path to cloned astral-api-mcp repo
+    }
+  }
+}
+```
+
+**VSCode MCP extension's config:**
+
+```json
+{
+  "servers": {
+    "astral-api": {
+      "command": "poetry",
+      "args": ["run", "start-server"],
+      "cwd": "${workspaceFolder}" // or the local path to cloned astral-api-mcp repo
+    }
+  }
+}
+```
+
+Once configured, you can connect to the MCP server from your client (i.e. GitHub Copilot Chat in `agent` mode) and start using the available tools.
+
 ### Testing
 
 Run the test suite:
+
 ```bash
 poetry run pytest tests/ -v
 ```
@@ -76,19 +131,17 @@ poetry run pytest tests/ -v
 ### Development
 
 This project uses:
+
 - **Poetry** for dependency management
 - **FastMCP** framework for MCP server implementation
 - **httpx** for HTTP requests to Astral API
 - **pytest** for testing
 
-## Project Overview
 
-We are exploring the development of a Model Context Protocol (MCP) agent that integrates with the [Astral API](https://docs.astral.global/getting-started) to enable intelligent querying and analysis of attestations submitted to blockchain ecosystems such as the Ethereum Attestation Service (EAS). This agent would support complex queries across spatial and temporal dimensions, such as filtering attestations by schema ID, location, or date range, while maintaining persistent context across sessions. By leveraging Astral’s structured API and EAS’s open schema model, the agent could automate common analytical workflows—like generating attestation heatmaps or tracking schema usage over time—making it a valuable tool for both research and production use cases. This early scoping phase would help assess feasibility and determine if this direction merits further investment.
+### Troubleshooting
 
-To learn more, please refer to the following [document](docs/ai/README.md) for additional details on the purpose, use cases, architecture, and development plans.
+If you encounter any `PORT IS IN USE` errors while running the MCP Inspector such as this:
 
-## Integration with the Recall Platform
+> [warning] [server stderr] ❌  MCP Inspector PORT IS IN USE at http://localhost:8881 ❌
 
-[Recall](https://docs.recall.network/advanced/overview) is a blockchain-based platform to support persistent, intelligent agents for onchain storage primitives and agent collaboration tools, enabling AI agents to maintain persistent memory, share data across sessions, and participate in a broader ecosystem of interconnected agents. By integrating the Astral MCP agent with Recall, we can transform it from a standalone location attestation query tool into a collaborative participant in an agent network with long-term memory—enabling it to store spatial analysis insights onchain, build knowledge graphs of location patterns over time, and share geospatial intelligence with other agents in the ecosystem. This integration unlocks powerful capabilities like persistent session context, cross-agent location verification services, and the ability to contribute to community-driven location intelligence, positioning your agent as both a consumer and provider of valuable spatial data within a growing network of AI agents that can learn from and build upon each other's discoveries.
-
-Once the Astral MCP agent is functional, we plan to integrate it with the Recall platform to enable persistent memory by storing insights onchain. You can find out more details on this next stage of development [in the following section](./docs/integration-with-recall.md).
+The MCP Inspector may already be running in another terminal or process or the port is occupied by another service that will need to be stopped. If the MCP Inspector is not running, it may have not exited cleanly, leaving an orphaned process i.e. `node.exe` still holding the port.  If that's the case, you can try running the **free-mcp-ports** scripts found [here](/scripts/).

--- a/astral_mcp_server/__init__.py
+++ b/astral_mcp_server/__init__.py
@@ -1,0 +1,13 @@
+"""
+Astral MCP Server
+
+A Model Context Protocol server that enables AI models to query location attestations
+using the Astral GraphQL endpoints and APIs.
+"""
+
+__version__ = "0.1.0"
+__author__ = "AR"
+
+from .server import app
+
+__all__ = ["app"]

--- a/astral_mcp_server/config.py
+++ b/astral_mcp_server/config.py
@@ -22,7 +22,7 @@ SERVER_VERSION = "0.1.0"
 def get_api_key() -> Optional[str]:
     """
     Retrieve API key from environment variables.
-    
+
     Returns:
         Optional[str]: API key if set, None otherwise
     """

--- a/astral_mcp_server/config.py
+++ b/astral_mcp_server/config.py
@@ -1,0 +1,29 @@
+"""
+Configuration module for Astral MCP Server
+
+Contains configuration constants and settings for the MCP server.
+"""
+
+import os
+from typing import Optional
+
+# Astral API Configuration
+ASTRAL_API_BASE_URL = "https://api.astral.global"
+ASTRAL_HEALTH_ENDPOINT = f"{ASTRAL_API_BASE_URL}/health"
+
+# HTTP Client Configuration
+DEFAULT_TIMEOUT = 30.0
+MAX_RETRIES = 3
+
+# MCP Server Configuration
+SERVER_NAME = "astral-mcp-server"
+SERVER_VERSION = "0.1.0"
+
+def get_api_key() -> Optional[str]:
+    """
+    Retrieve API key from environment variables.
+    
+    Returns:
+        Optional[str]: API key if set, None otherwise
+    """
+    return os.getenv("ASTRAL_API_KEY")

--- a/astral_mcp_server/server.py
+++ b/astral_mcp_server/server.py
@@ -1,0 +1,138 @@
+"""
+Astral MCP Server
+
+A FastMCP-based server that provides tools for querying location attestations
+through the Astral API.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+# Import from absolute paths when running as script
+try:
+    from .config import (
+        ASTRAL_HEALTH_ENDPOINT,
+        DEFAULT_TIMEOUT,
+        MAX_RETRIES,
+        SERVER_NAME,
+        SERVER_VERSION,
+        get_api_key,
+    )
+except ImportError:
+    # Fallback for when running as script
+    from config import (
+        ASTRAL_HEALTH_ENDPOINT,
+        DEFAULT_TIMEOUT,
+        MAX_RETRIES,
+        SERVER_NAME,
+        SERVER_VERSION,
+        get_api_key,
+    )
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Initialize FastMCP server
+app = FastMCP(SERVER_NAME)
+
+
+@app.tool()
+async def check_astral_api_health() -> Dict[str, Any]:
+    """
+    Check the health status of the Astral API.
+    
+    Performs a health check against the Astral API endpoint to verify
+    connectivity and service availability.
+    
+    Returns:
+        Dict[str, Any]: Health check response containing status information
+        
+    Raises:
+        Exception: If the health check fails or times out
+    """
+    try:
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            logger.info(f"Checking Astral API health at: {ASTRAL_HEALTH_ENDPOINT}")
+            
+            response = await client.get(ASTRAL_HEALTH_ENDPOINT)
+            response.raise_for_status()
+            
+            health_data = response.json()
+            
+            result = {
+                "status": "healthy",
+                "endpoint": ASTRAL_HEALTH_ENDPOINT,
+                "response_code": response.status_code,
+                "response_time_ms": int(response.elapsed.total_seconds() * 1000),
+                "api_data": health_data,
+            }
+            
+            logger.info(f"Health check successful: {result['status']}")
+            return result
+            
+    except httpx.TimeoutException:
+        error_msg = f"Health check timed out after {DEFAULT_TIMEOUT} seconds"
+        logger.error(error_msg)
+        raise Exception(error_msg)
+        
+    except httpx.HTTPStatusError as e:
+        error_msg = f"Health check failed with status {e.response.status_code}: {e.response.text}"
+        logger.error(error_msg)
+        raise Exception(error_msg)
+        
+    except Exception as e:
+        error_msg = f"Health check failed: {str(e)}"
+        logger.error(error_msg)
+        raise Exception(error_msg)
+
+
+@app.tool()
+async def get_server_info() -> Dict[str, Any]:
+    """
+    Get information about this MCP server.
+    
+    Returns basic metadata and configuration information about the
+    Astral MCP server instance.
+    
+    Returns:
+        Dict[str, Any]: Server information including name, version, and capabilities
+    """
+    api_key_configured = get_api_key() is not None
+    
+    return {
+        "name": SERVER_NAME,
+        "version": SERVER_VERSION,
+        "description": "MCP server for querying Astral location attestations",
+        "api_key_configured": api_key_configured,
+        "astral_health_endpoint": ASTRAL_HEALTH_ENDPOINT,
+        "capabilities": [
+            "health_check",
+            "server_info",
+        ],
+    }
+
+
+def main() -> None:
+    """
+    Main entry point for running the MCP server.
+    
+    This function starts the FastMCP server and handles the event loop.
+    """
+    logger.info(f"Starting {SERVER_NAME} v{SERVER_VERSION}")
+    
+    try:
+        app.run()
+    except KeyboardInterrupt:
+        logger.info("Server shutdown requested")
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+create = true
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[tool.poetry]
+name = "astral-mcp-server"
+version = "0.1.0"
+description = "A MCP (Model Context Protocol) server that enables AI models to query location attestations using the Astral GraphQL endpoints and APIs"
+authors = ["AR"]
+readme = "README.md"
+packages = [{include = "astral_mcp_server"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+httpx = "^0.27.0"
+mcp = {extras = ["cli"], version = "^1.0.0"}
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+pytest-asyncio = "^0.24.0"
+black = "^24.0.0"
+flake8 = "^7.0.0"
+mypy = "^1.8.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+astral-mcp-server = "astral_mcp_server.server:main"
+
+[tool.black]
+line-length = 88
+target-version = ['py312']
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-astral-mcp-server = "astral_mcp_server.server:main"
+start-server = "astral_mcp_server.server:main"
 
 [tool.black]
 line-length = 88

--- a/scripts/free-mcp-ports.ps1
+++ b/scripts/free-mcp-ports.ps1
@@ -1,0 +1,102 @@
+# PowerShell script to free MCP Inspector ports defined in .env-mcp-inspector
+# Usage: pwsh -File scripts/free-mcp-ports.ps1 [optional path to .env file]
+
+param(
+  [string]$EnvFilePath
+)
+
+if (-not $EnvFilePath) {
+  $EnvFilePath = Join-Path (Join-Path $PSScriptRoot "..") ".env-mcp-inspector"
+}
+
+function Read-DotEnv {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path)) {
+    throw ".env file not found at $Path"
+  }
+  $vars = @{}
+  Get-Content -LiteralPath $Path | ForEach-Object {
+    $line = $_.Trim()
+    if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith('#')) { return }
+    $kv = $line -split '=', 2
+    if ($kv.Count -eq 2) {
+      $key = $kv[0].Trim()
+      $val = $kv[1].Trim()
+      if ($val.StartsWith('"') -and $val.EndsWith('"')) { $val = $val.Substring(1, $val.Length-2) }
+      if ($val.StartsWith("'") -and $val.EndsWith("'")) { $val = $val.Substring(1, $val.Length-2) }
+      $vars[$key] = $val
+    }
+  }
+  return $vars
+}
+
+function Get-ListeningPids {
+  param([int]$Port)
+  $pids = @()
+  try {
+    $conns = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop
+    if ($conns) {
+      $pids = $conns | Where-Object { $_.OwningProcess } | Select-Object -ExpandProperty OwningProcess -Unique
+    }
+  } catch {
+    # Fallback to netstat parsing
+    $netstatMatches = netstat -aon | Select-String -Pattern "LISTENING" | Where-Object { $_ -match ":$Port\b" }
+    foreach ($m in $netstatMatches) {
+      $parts = ($m.ToString() -replace ' +', ' ').Trim().Split(' ')
+      if ($parts.Length -ge 5) {
+        $procId = $parts[-1]
+        if ($procId -match '^\d+$') { $pids += [int]$procId }
+      }
+    }
+    $pids = $pids | Select-Object -Unique
+  }
+  return $pids
+}
+
+function Stop-Pids {
+  param([int[]]$Pids)
+  foreach ($procId in $Pids) {
+    try {
+      $proc = Get-Process -Id $procId -ErrorAction Stop
+      Write-Host ("Killing PID {0} ({1})" -f $procId, $proc.ProcessName)
+      Stop-Process -Id $procId -Force -ErrorAction Stop
+    } catch {
+      try {
+        taskkill /PID $procId /F | Out-Null
+        Write-Host ("Killed PID {0} via taskkill" -f $procId)
+      } catch {
+        Write-Warning ("Failed to kill PID {0}: {1}" -f $procId, $_.Exception.Message)
+      }
+    }
+  }
+}
+
+try {
+  $envVars = Read-DotEnv -Path $EnvFilePath
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+
+$ports = @()
+if ($envVars.ContainsKey('CLIENT_PORT')) { $ports += [int]$envVars['CLIENT_PORT'] }
+if ($envVars.ContainsKey('SERVER_PORT')) { $ports += [int]$envVars['SERVER_PORT'] }
+$ports = $ports | Sort-Object -Unique
+
+if ($ports.Count -eq 0) {
+  Write-Error "No CLIENT_PORT or SERVER_PORT found in $EnvFilePath"
+  exit 1
+}
+
+Write-Host "Checking ports: $($ports -join ', ') from $EnvFilePath"
+foreach ($port in $ports) {
+  $pids = @(Get-ListeningPids -Port $port)
+  if ($pids.Count -gt 0) {
+    Write-Host "Port $port is in use by PIDs: $($pids -join ', ')"
+    Stop-Pids -Pids $pids
+  } else {
+    Write-Host "Port $port is free."
+  }
+}
+
+Write-Host "Done. If some processes persist, try running this script as Administrator."

--- a/scripts/free-mcp-ports.sh
+++ b/scripts/free-mcp-ports.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Bash script to free MCP Inspector ports defined in .env-mcp-inspector
+# Usage: bash scripts/free-mcp-ports.sh [optional path to .env file]
+set -euo pipefail
+
+ENV_FILE=${1:-"$(cd "$(dirname "$0")"/.. && pwd)/.env-mcp-inspector"}
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo ".env file not found at $ENV_FILE" >&2
+  exit 1
+fi
+
+# Load variables: only CLIENT_PORT and SERVER_PORT
+CLIENT_PORT=""; SERVER_PORT=""
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" =~ ^\s*# ]] && continue
+  if [[ "$line" =~ ^CLIENT_PORT= ]]; then
+    CLIENT_PORT=${line#CLIENT_PORT=}
+    CLIENT_PORT=${CLIENT_PORT%$'\r'}
+  elif [[ "$line" =~ ^SERVER_PORT= ]]; then
+    SERVER_PORT=${line#SERVER_PORT=}
+    SERVER_PORT=${SERVER_PORT%$'\r'}
+  fi
+done < "$ENV_FILE"
+
+PORTS=()
+[[ -n "$CLIENT_PORT" ]] && PORTS+=("$CLIENT_PORT")
+[[ -n "$SERVER_PORT" ]] && PORTS+=("$SERVER_PORT")
+
+if [[ ${#PORTS[@]} -eq 0 ]]; then
+  echo "No CLIENT_PORT or SERVER_PORT found in $ENV_FILE" >&2
+  exit 1
+fi
+
+echo "Checking ports: ${PORTS[*]} from $ENV_FILE"
+
+kill_pids() {
+  local pid
+  for pid in "$@"; do
+    if ps -p "$pid" > /dev/null 2>&1; then
+      echo "Killing PID $pid"
+      kill -9 "$pid" || true
+    fi
+  done
+}
+
+for port in "${PORTS[@]}"; do
+  # Try lsof, then fallback to ss/netstat
+  PIDS=""
+  if command -v lsof >/dev/null 2>&1; then
+    PIDS=$(lsof -t -iTCP:"$port" -sTCP:LISTEN || true)
+  fi
+  if [[ -z "$PIDS" ]] && command -v ss >/dev/null 2>&1; then
+    PIDS=$(ss -ltnp 2>/dev/null | awk -v p=":$port" '$4 ~ p {print $6}' | sed -E 's/.*pid=([0-9]+).*/\1/' | sort -u)
+  fi
+  if [[ -z "$PIDS" ]] && command -v netstat >/dev/null 2>&1; then
+    # netstat -ltnp output parsing (Linux)
+    PIDS=$(netstat -ltnp 2>/dev/null | awk -v p=":$port" '$4 ~ p {print $7}' | cut -d'/' -f1 | grep -E '^[0-9]+$' | sort -u)
+  fi
+
+  if [[ -n "$PIDS" ]]; then
+    echo "Port $port is in use by PIDs: $(echo "$PIDS" | tr '\n' ' ' | sed 's/ $//')"
+    kill_pids $PIDS
+  else
+    echo "Port $port is free."
+  fi
+
+done
+
+echo "Done. If some processes persist, try running with sudo."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test package for Astral MCP Server
+"""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,30 @@
+"""
+Tests for the Astral MCP Server
+"""
+
+import pytest
+from astral_mcp_server import __version__
+
+
+def test_version():
+    """Test that version is properly defined."""
+    assert __version__ == "0.1.0"
+
+
+def test_import():
+    """Test that the main module can be imported."""
+    import astral_mcp_server
+    assert hasattr(astral_mcp_server, "app")
+
+
+@pytest.mark.asyncio
+async def test_server_info_tool():
+    """Test the server info tool."""
+    from astral_mcp_server.server import get_server_info
+    
+    info = await get_server_info()
+    
+    assert info["name"] == "astral-mcp-server"
+    assert info["version"] == "0.1.0"
+    assert "capabilities" in info
+    assert isinstance(info["capabilities"], list)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,9 +21,9 @@ def test_import():
 async def test_server_info_tool():
     """Test the server info tool."""
     from astral_mcp_server.server import get_server_info
-    
+
     info = await get_server_info()
-    
+
     assert info["name"] == "astral-mcp-server"
     assert info["version"] == "0.1.0"
     assert "capabilities" in info


### PR DESCRIPTION
Session 1.1 - Python Environment & Project Structure:

Add Poetry-managed project with complete pyproject.toml Create organized package structure (astral_mcp_server/, tests/) Update .gitignore with Poetry-specific entries
Add comprehensive README.md with setup instructions Include dev dependencies (pytest, black, flake8, mypy, pytest-asyncio)

Session 1.2 - MCP Server Skeleton & Astral API Connectivity:

Implement FastMCP server with proper async patterns Add Astral API health check tool with error handling Create configuration module for API endpoints
Add comprehensive logging and documentation
Include complete test suite with async support